### PR TITLE
Disable SwiftLint nesting rule

### DIFF
--- a/Framework/SwiftLint.stencil
+++ b/Framework/SwiftLint.stencil
@@ -67,6 +67,7 @@ opt_in_rules:
 
 disabled_rules:
 - force_cast
+- nesting
 - todo
 - type_name
 

--- a/iOS/SwiftLint-light.stencil
+++ b/iOS/SwiftLint-light.stencil
@@ -64,6 +64,7 @@ opt_in_rules:
 
 disabled_rules:
 - force_cast
+- nesting
 - todo
 - type_name
 

--- a/iOS/SwiftLint-zero.stencil
+++ b/iOS/SwiftLint-zero.stencil
@@ -62,6 +62,7 @@ opt_in_rules:
 
 disabled_rules:
 - force_cast
+- nesting
 - todo
 - type_name
 

--- a/iOS/SwiftLint.stencil
+++ b/iOS/SwiftLint.stencil
@@ -66,6 +66,7 @@ opt_in_rules:
 
 disabled_rules:
 - force_cast
+- nesting
 - todo
 - type_name
 


### PR DESCRIPTION
This PR disables the SwiftLint `nesting` rule. There are cases where nesting can help breaking down complexity even when not at top- or sub-top-level (e. g. when using a `typealias` within a function). This is why I suggest to remove it.