### PR TITLE
[SwiftLint] Swap ib_action with other_method

### DIFF
--- a/Framework/SwiftLint.stencil
+++ b/Framework/SwiftLint.stencil
@@ -118,8 +118,8 @@ type_contents_order:
     - initializer
     - type_method
     - view_life_cycle_method
-    - ib_action
     - other_method
+    - ib_action
     - subscript
 
 # Custom Rules

--- a/iOS/SwiftLint.stencil
+++ b/iOS/SwiftLint.stencil
@@ -116,8 +116,8 @@ type_contents_order:
     - initializer
     - type_method
     - view_life_cycle_method
-    - ib_action
     - other_method
+    - ib_action
     - subscript
 
 # Custom Rules


### PR DESCRIPTION
Adjust `type_contents_order` SwiftLint rule to require other methods to precede IBActions.