### PR TITLE
[SwiftLint] Remove rule no_extension_access_modifier

### DIFF
--- a/JamitLabs/App/SwiftLint.stencil
+++ b/JamitLabs/App/SwiftLint.stencil
@@ -31,7 +31,6 @@ opt_in_rules:
 - multiline_parameters
 - multiline_parameters_brackets
 - nimble_operator
-- no_extension_access_modifier
 - number_separator
 - object_literal
 - operator_usage_whitespace


### PR DESCRIPTION
Remove the `no_extension_access_modifier` rule to allow access levels for extensions