### PR TITLE
Use nested_type_separator option for file_name rule

### DIFF
--- a/JamitLabs/App/SwiftLint.stencil
+++ b/JamitLabs/App/SwiftLint.stencil
@@ -85,6 +85,7 @@ file_header:
   required_pattern: \/\/ Copyright © \d{4} {{ rightholder }}\. All rights reserved\.
 
 file_name:
+  nested_type_separator: ""
   suffix_pattern: "Extensions?|\\+.*"
 
 file_types_order:


### PR DESCRIPTION
Should be merged together with https://github.com/JamitLabs/NewProjectTemplate-iOS/pull/23.